### PR TITLE
Freeze metadata default values

### DIFF
--- a/lib/event_framework/event.rb
+++ b/lib/event_framework/event.rb
@@ -15,7 +15,7 @@ module EventFramework
 
     class Metadata < BaseMetadata
       attribute :user_id, Types::UUID
-      attribute :metadata_type, Types.Value("attributed").default("attributed")
+      attribute :metadata_type, Types.Value("attributed").default("attributed".freeze)
 
       def self.new_with_fallback(fallback_class:, **args)
         new(args)
@@ -27,11 +27,11 @@ module EventFramework
     end
 
     class UnattributedMetadata < BaseMetadata
-      attribute :metadata_type, Types.Value("unattributed").default("unattributed")
+      attribute :metadata_type, Types.Value("unattributed").default("unattributed".freeze)
     end
 
     class SystemMetadata < BaseMetadata
-      attribute :metadata_type, Types.Value("system").default("system")
+      attribute :metadata_type, Types.Value("system").default("system".freeze)
     end
 
     attribute :id, Types::UUID


### PR DESCRIPTION
To fix the following warnings:

    [dry-types] "attributed" is mutable. Be careful: types will return the same instance of the default value every time. Call `.freeze` when setting the default or pass `shared: true` to discard this warning.
    /Users/odin/Dev/github/cultureamp/event_framework/lib/event_framework/event.rb:18:in `<class:Metadata>'
    [dry-types] "unattributed" is mutable. Be careful: types will return the same instance of the default value every time. Call `.freeze` when setting the default or pass `shared: true` to discard this warning.
    /Users/odin/Dev/github/cultureamp/event_framework/lib/event_framework/event.rb:30:in `<class:UnattributedMetadata>'
    [dry-types] "system" is mutable. Be careful: types will return the same instance of the default value every time. Call `.freeze` when setting the default or pass `shared: true` to discard this warning.
    /Users/odin/Dev/github/cultureamp/event_framework/lib/event_framework/event.rb:34:in `<class:SystemMetadata>'