### PR TITLE
Support deserializing "system" metadata

### DIFF
--- a/lib/event_framework/event.rb
+++ b/lib/event_framework/event.rb
@@ -34,6 +34,12 @@ module EventFramework
       attribute :metadata_type, Types.Value("system").default("system".freeze)
     end
 
+    METADATA_TYPES = {
+      attributed: Metadata,
+      unattributed: UnattributedMetadata,
+      system: SystemMetadata,
+    }
+
     attribute :id, Types::UUID
     attribute :sequence, Types::Strict::Integer
     attribute :aggregate_id, Types::UUID

--- a/lib/event_framework/event_store/event_builder.rb
+++ b/lib/event_framework/event_store/event_builder.rb
@@ -44,14 +44,11 @@ module EventFramework
       end
 
       def build_metadata(metadata)
-        case metadata[:metadata_type]
-        when "attributed"
-          Event::Metadata.new(metadata)
-        when "unattributed"
-          Event::UnattributedMetadata.new(metadata)
-        else
+        metadata_class = Event::METADATA_TYPES.fetch(metadata[:metadata_type].to_sym) do
           raise "unknown metadata_type: #{metadata[:metadata_type].inspect}"
         end
+
+        metadata_class.new(metadata)
       end
     end
   end

--- a/spec/event_store/event_builder_spec.rb
+++ b/spec/event_store/event_builder_spec.rb
@@ -102,6 +102,19 @@ module EventFramework
         end
       end
 
+      describe "system metadata" do
+        let(:event) do
+          row[:metadata]["metadata_type"] = "system"
+          row[:metadata].delete("user_id")
+          event_builder.call(row)
+        end
+
+        it "has is an UnattributedMetadata" do
+          expect(event.metadata).to be_an Event::SystemMetadata
+          expect(event.metadata.metadata_type).to eq "system"
+        end
+      end
+
       describe "upcasting" do
         let(:event) { event_builder.call(row.merge(event_type: "EventBuilderUpcastingTested")) }
 

--- a/spec/event_store/event_builder_spec.rb
+++ b/spec/event_store/event_builder_spec.rb
@@ -96,7 +96,7 @@ module EventFramework
           event_builder.call(row)
         end
 
-        it "has is an UnattributedMetadata" do
+        it "uses the UnattributedMetadata class" do
           expect(event.metadata).to be_an Event::UnattributedMetadata
           expect(event.metadata.metadata_type).to eq "unattributed"
         end
@@ -109,7 +109,7 @@ module EventFramework
           event_builder.call(row)
         end
 
-        it "has is an UnattributedMetadata" do
+        it "uses the SystemMetadata class" do
           expect(event.metadata).to be_an Event::SystemMetadata
           expect(event.metadata.metadata_type).to eq "system"
         end


### PR DESCRIPTION
I've moved the mapping into the event class so it's less likely to be forgotten in the future.