### PR TITLE
Allow saving SystemMetadata through StagedEvent

### DIFF
--- a/lib/event_framework/staged_event.rb
+++ b/lib/event_framework/staged_event.rb
@@ -9,7 +9,7 @@ module EventFramework
     attribute :aggregate_id, Types::UUID
     attribute :aggregate_sequence, Types::Strict::Integer
     attribute :domain_event, DomainEvent
-    attribute :metadata, (Event::Metadata | Event::UnattributedMetadata).optional
+    attribute :metadata, (Event::Metadata | Event::UnattributedMetadata | Event::SystemMetadata).optional
 
     def body
       domain_event.to_h


### PR DESCRIPTION
I think we should look into removing the need for having a separate `StagedEvent` so that we don't have these issues again.