### PR TITLE
Define a sum type for the metadata

### DIFF
--- a/lib/event_framework/event.rb
+++ b/lib/event_framework/event.rb
@@ -39,6 +39,7 @@ module EventFramework
       unattributed: UnattributedMetadata,
       system: SystemMetadata,
     }
+    AnyMetadata = Metadata | UnattributedMetadata | SystemMetadata
 
     attribute :id, Types::UUID
     attribute :sequence, Types::Strict::Integer
@@ -46,7 +47,7 @@ module EventFramework
     attribute :aggregate_sequence, Types::Strict::Integer
     attribute :created_at, Types::JSON::Time
 
-    attribute :metadata, Metadata | UnattributedMetadata | SystemMetadata
+    attribute :metadata, AnyMetadata
 
     attribute :domain_event, DomainEvent
 

--- a/lib/event_framework/staged_event.rb
+++ b/lib/event_framework/staged_event.rb
@@ -9,7 +9,7 @@ module EventFramework
     attribute :aggregate_id, Types::UUID
     attribute :aggregate_sequence, Types::Strict::Integer
     attribute :domain_event, DomainEvent
-    attribute :metadata, (Event::Metadata | Event::UnattributedMetadata | Event::SystemMetadata).optional
+    attribute :metadata, Event::AnyMetadata.optional
 
     def body
       domain_event.to_h


### PR DESCRIPTION
Follow up from https://github.com/cultureamp/event_framework/pull/9.

This is slightly nicer than duplicating the definition across `Event` and `StagedEvent`, but I still think we can do better in the future.