### PR TITLE
Pass event_builder in as a dependency

### DIFF
--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -11,12 +11,13 @@ module EventFramework
       def initialize(
         database:, event_type_resolver:,
         logger: Logger.new(STDOUT),
-        lock_timeout_milliseconds: LOCK_TIMEOUT_MILLISECONDS
+        lock_timeout_milliseconds: LOCK_TIMEOUT_MILLISECONDS,
+        event_builder: EventBuilder.new(event_type_resolver: event_type_resolver)
       )
         @database = database
         @event_type_resolver = event_type_resolver
         @logger = logger
-        @event_builder = EventBuilder.new(event_type_resolver: event_type_resolver)
+        @event_builder = event_builder
         @lock_timeout_milliseconds = lock_timeout_milliseconds
       end
 

--- a/lib/event_framework/event_store/source.rb
+++ b/lib/event_framework/event_store/source.rb
@@ -3,11 +3,14 @@ module EventFramework
     class Source
       LIMIT = 1000
 
-      def initialize(database:, event_type_resolver:, logger: Logger.new(STDOUT))
+      def initialize(
+        database:, event_type_resolver:, logger: Logger.new(STDOUT),
+        event_builder: EventBuilder.new(event_type_resolver: event_type_resolver)
+      )
         @database = database
         @event_type_resolver = event_type_resolver
         @logger = logger
-        @event_builder = EventBuilder.new(event_type_resolver: event_type_resolver)
+        @event_builder = event_builder
       end
 
       def get_after(sequence, event_classes: nil)


### PR DESCRIPTION
If an event that is being processed does not conform to the specific
structure that the EventBuilder is expecting, the event store will fail.

By passing in the EventBuilder as a dependency, we are able to build an
Event Framework Event from any stored event structure.

Interestingly, ruby allows you to reference a given kwarg as a parameter
in a different default kwarg value, as in
```
event_builder: EventBuilder.new(event_type_resolver: event_type_resolver)
```

Culture Amp Internal Context:

I want to be able to use this gem to process events from Influx. This change will allow me to build an `EventFramework::Event` from the structure in said events.