### PR TITLE
Remove retrying from UnableToGetLockError

### DIFF
--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -2,7 +2,7 @@ module EventFramework
   module EventStore
     class Sink
       AggregateIdMismatchError = Class.new(Error)
-      UnableToGetLockError = Class.new(RetriableException)
+      UnableToGetLockError = Class.new(Error)
       StaleAggregateError = Class.new(RetriableException)
 
       # 10 seconds


### PR DESCRIPTION
A small follow up to #21. Initially I decided to keep the number of changes small. Thinking about it more though I don't think we should retry (in the command handler) if we're unable to get a lock. The timeout is 10 seconds by default so with a retry we're looking at waiting for a long time.

The retry numbers in the command handler:

```ruby
FAILURE_RETRY_THRESHOLD = 5
FAILURE_RETRY_SLEEP_INTERVAL = 0.5
```

Which means:

```
10 seconds * 5 retries + 0.5 seconds * 5 retries = 52.5 seconds
```