### PR TITLE
Increased event sink tracing & Postgres sink function

### DIFF
--- a/lib/event_framework/bounded_context.rb
+++ b/lib/event_framework/bounded_context.rb
@@ -80,10 +80,15 @@ module EventFramework
         end
 
         container.register("event_store.sink") do
-          EventStore::Sink.new(
+          tracer = container.key?("tracer") ? container["tracer"] : nil
+
+          sink_options = {
             database: database(event_store_database),
-            event_type_resolver: container.resolve("event_store.event_type_resolver")
-          )
+            event_type_resolver: container.resolve("event_store.event_type_resolver"),
+            tracer: tracer
+          }.compact
+
+          EventStore::Sink.new(**sink_options)
         end
 
         container.register("event_store.source") do

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -82,7 +82,6 @@ module EventFramework
                       event_type: serialized_event_type.event_type,
                       body: body,
                       metadata: metadata)
-                    )
                   end
                 end
               rescue Sequel::UniqueConstraintViolation

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -17,11 +17,10 @@ module EventFramework
         @database = database
         @event_type_resolver = event_type_resolver
         @logger = logger
-        @tracer = tracer
+        # @tracer = tracer
+        @tracer = Datadog.tracer # Hard-coding this to see if it gives us what we want
         @event_builder = EventBuilder.new(event_type_resolver: event_type_resolver)
         @lock_timeout_milliseconds = lock_timeout_milliseconds
-
-        logger.info(msg: "event_framework.event_store.sink.initialize", tracer: tracer.class.name)
       end
 
       def transaction

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -11,11 +11,13 @@ module EventFramework
       def initialize(
         database:, event_type_resolver:,
         logger: Logger.new(STDOUT),
+        tracer: EventFramework::Tracer::NullTracer.new,
         lock_timeout_milliseconds: LOCK_TIMEOUT_MILLISECONDS
       )
         @database = database
         @event_type_resolver = event_type_resolver
         @logger = logger
+        @tracer = tracer
         @event_builder = EventBuilder.new(event_type_resolver: event_type_resolver)
         @lock_timeout_milliseconds = lock_timeout_milliseconds
       end
@@ -41,7 +43,7 @@ module EventFramework
 
       private
 
-      attr_reader :database, :event_type_resolver, :logger, :event_builder, :lock_timeout_milliseconds
+      attr_reader :database, :event_type_resolver, :logger, :tracer, :event_builder, :lock_timeout_milliseconds
 
       def sink_staged_events(staged_events)
         new_event_rows = []

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -20,6 +20,8 @@ module EventFramework
         @tracer = tracer
         @event_builder = EventBuilder.new(event_type_resolver: event_type_resolver)
         @lock_timeout_milliseconds = lock_timeout_milliseconds
+
+        logger.info(msg: "event_framework.event_store.sink.initialize", tracer: tracer.class.name)
       end
 
       def transaction

--- a/lib/event_framework/tracer.rb
+++ b/lib/event_framework/tracer.rb
@@ -1,7 +1,7 @@
 module EventFramework
   module Tracer
     class NullTracer
-      def trace(_span_label, resource:)
+      def trace(_span_label, resource: nil)
         yield(NullSpan.new)
       end
     end


### PR DESCRIPTION
This PR makes it possible to inject a tracer into the sink object (via a "tracer" registration on the bounded context container) and then adds a significant number of tracing spans to the sinking process. It's intended to give us more information when doing some performance analysis.

Once this is done, it may be useful to retain the injected tracer and keep a smaller number of broader spans for future use.