### PR TITLE
Fix errors in event processor runner

### DIFF
--- a/lib/event_framework/event_processor_runner.rb
+++ b/lib/event_framework/event_processor_runner.rb
@@ -17,9 +17,14 @@ module EventFramework
       end
     end
 
-    def initialize(processor_class:, domain_context:)
+    def initialize(
+      processor_class:,
+      domain_context:,
+      tracer: EventFramework::Tracer::NullTracer.new
+    )
       @processor_class = processor_class
       @domain_context = domain_context
+      @tracer = tracer
     end
 
     def call
@@ -37,6 +42,7 @@ module EventFramework
             logger: logger,
             bookmark: bookmark,
             event_source: event_source,
+            tracer: @tracer,
             &ready_to_stop
           )
         end

--- a/lib/event_framework/event_processor_runner.rb
+++ b/lib/event_framework/event_processor_runner.rb
@@ -20,10 +20,12 @@ module EventFramework
     def initialize(
       processor_class:,
       domain_context:,
+      logger: Logger.new($stdout),
       tracer: EventFramework::Tracer::NullTracer.new
     )
       @processor_class = processor_class
       @domain_context = domain_context
+      @logger = logger
       @tracer = tracer
     end
 
@@ -31,7 +33,6 @@ module EventFramework
       set_process_name
 
       event_processor = processor_class.new
-      logger = Logger.new(STDOUT)
       bookmark = checkout_bookmark
       event_source = domain_context.container.resolve("event_store.source")
 
@@ -51,7 +52,7 @@ module EventFramework
 
     private
 
-    attr_reader :processor_class, :domain_context
+    attr_reader :processor_class, :domain_context, :logger
 
     def checkout_bookmark
       projection_database = domain_context.database(:projections)

--- a/spec/event_processor_runner_spec.rb
+++ b/spec/event_processor_runner_spec.rb
@@ -14,8 +14,7 @@ module EventFramework
 
       before do
         allow(event_processor_class).to receive(:new).and_return(event_processor)
-
-        allow(Logger).to receive(:new).with(STDOUT).at_least(1).and_return(logger)
+        allow(Logger).to receive(:new).with($stdout).at_least(1).and_return(logger)
 
         projection_database = instance_spy(EventFramework::DatabaseConnection)
         allow(TestDomain).to receive(:database).with(:projections).and_return(projection_database)
@@ -42,8 +41,27 @@ module EventFramework
         EventProcessorRunner.new(
           processor_class: event_processor_class,
           domain_context: TestDomain,
-          tracer: tracer
+          tracer: tracer,
+          logger: logger
         ).call
+      end
+
+      context "when unable to checkout a bookmark" do
+        it "logs the error" do
+          expect(bookmark_repository).to receive(:checkout).and_raise(BookmarkRepository::UnableToCheckoutBookmarkError)
+          allow(bookmark_repository).to receive(:checkout).and_return(bookmark)
+          allow(EventFramework::EventProcessorWorker).to receive(:call)
+
+          expect(logger).to receive(:info).with(
+            processor_class_name: "FooProjector",
+            msg: "EventFramework::BookmarkRepository::UnableToCheckoutBookmarkError"
+          )
+
+          EventProcessorRunner.new(
+            processor_class: event_processor_class,
+            domain_context: TestDomain
+          ).call
+        end
       end
     end
   end


### PR DESCRIPTION
The runner was missing the new `tracer` dependency that is required by the EventProcessorWorker, so added that in.

Also, the `checkout_bookmark` method was trying to log when it rescued from the `UnableToCheckoutBookmarkError`, but the logger was being instantiated as a local variable in the `#call` method, causing it to throw an exception itself. Have now refactored to pass the logger in as a dependency, and making it available as an `attr_reader`