### PR TITLE
Use internal ExponentialBackoff with max sleep in event processor supervisor

### DIFF
--- a/spec/event_processor_supervisor_spec.rb
+++ b/spec/event_processor_supervisor_spec.rb
@@ -18,7 +18,11 @@ module EventFramework
 
       it "forks each event processor" do
         expect(described_class::OnForkedError).to receive(:new).with("FooProjector").and_return(on_forked_error)
-        expect(process_manager).to receive(:fork).with("FooProjector", on_error: on_forked_error).and_yield(ready_to_stop_wrapper)
+        expect(process_manager).to receive(:fork).with(
+          "FooProjector",
+          on_error: on_forked_error,
+          retry_strategy: ExponentialBackoff
+        ).and_yield(ready_to_stop_wrapper)
         expect(Logger).to receive(:new).with(STDOUT).at_least(1).and_return(logger)
         expect(event_processor_class).to receive(:new).and_return(event_processor)
         expect(bookmark_repository_class).to receive(:new)


### PR DESCRIPTION
If we fix an issue with an event processor without needing to do a full deploy/restart of the event processors we can sometimes get into a state where an event processor might be `sleep`ing for a very long time with no way to get it to try again. A simple fix for this is to simply max out the sleep time at 5 minutes.

We're re-using an existing `ExponentialBackoff` that's already used by the `EventProcessorRunner`.