### PR TITLE
Switch sinking events to a Postgresql function

### DIFF
--- a/db/event_store/migrations/20201110221547_create_events_function.rb
+++ b/db/event_store/migrations/20201110221547_create_events_function.rb
@@ -1,0 +1,48 @@
+Sequel.migration do
+  up do
+    run(<<~SQL)
+      CREATE OR REPLACE FUNCTION insert_events(
+        _aggregateId uuid,
+        _eventTypes text[],
+        _aggregateTypes text[],
+        _aggregateSequences int[],
+        _bodies jsonb[],
+        _metadatas jsonb[],
+        _lockTimeoutMilliseconds int
+      ) RETURNS SETOF events as $$
+        DECLARE
+          aggregate_sequence int;
+          index int := 1;
+        BEGIN
+          -- Set a local lock_timeout within a transaction then get an exclusive
+          -- advisory lock so that we're the only database connection that can
+          -- sink an event.
+          --
+          -- If you're modifing the locking logic you can test that it's working
+          -- correctly using the ./bin/demonstrate_event_sequence_id_gaps script.
+          EXECUTE 'SET LOCAL lock_timeout TO ' || _lockTimeoutMilliseconds;
+          PERFORM pg_advisory_xact_lock(-1);
+
+          foreach aggregate_sequence IN ARRAY(_aggregateSequences)
+            loop
+              RETURN QUERY INSERT INTO EVENTS
+                (aggregate_id, aggregate_sequence, event_type, aggregate_type, body, metadata)
+              VALUES
+                (
+                  _aggregateId,
+                  _aggregateSequences[index],
+                  _eventTypes[index],
+                  _aggregateTypes[index],
+                  _bodies[index],
+                  _metadatas[index]
+                )
+              RETURNING *;
+              index := index + 1;
+            end loop;
+
+          RETURN;
+        END;
+      $$ language plpgsql;
+    SQL
+  end
+end

--- a/db/event_store/structure.sql
+++ b/db/event_store/structure.sql
@@ -9,22 +9,9 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
@@ -59,8 +46,6 @@ END $$;
 
 
 SET default_tablespace = '';
-
-SET default_with_oids = false;
 
 --
 -- Name: events; Type: TABLE; Schema: public; Owner: -

--- a/db/projections/structure.sql
+++ b/db/projections/structure.sql
@@ -9,26 +9,11 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET default_tablespace = '';
-
-SET default_with_oids = false;
 
 --
 -- Name: bookmarks; Type: TABLE; Schema: public; Owner: -

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -72,6 +72,10 @@ module EventFramework
 
           new_event_rows = database.from(insert_events_function).select_all.to_a
         rescue Sequel::UniqueConstraintViolation
+          logger.info(
+            msg: "event_framework.event_store.sink.stale_aggregate_error",
+            correlation_id: staged_events.first.metadata.correlation_id
+          )
           raise StaleAggregateError, "error saving aggregate_id #{aggregate_id}, aggregate_sequence mismatch"
         rescue Sequel::DatabaseLockTimeout => e
           logger.info(

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -56,8 +56,8 @@ module EventFramework
           serialized_event_type = event_type_resolver.serialize(staged_event.domain_event.class)
           {
             aggregate_sequence: staged_event.aggregate_sequence,
-            aggregate_type: serialized_event_type.aggregate_type,
-            event_type: serialized_event_type.event_type,
+            aggregate_type: Sequel.cast(serialized_event_type.aggregate_type, "text"),
+            event_type: Sequel.cast(serialized_event_type.event_type, "text"),
             body: Sequel.pg_jsonb(staged_event.body),
             metadata: Sequel.pg_jsonb(staged_event.metadata.to_h)
           }
@@ -67,8 +67,8 @@ module EventFramework
           insert_events_function = Sequel.function(
             :insert_events,
             Sequel.cast(aggregate_id, "uuid"),
-            Sequel.pg_array(serialized_events.map { |e| Sequel.cast(e[:event_type], "text") }),
-            Sequel.pg_array(serialized_events.map { |e| Sequel.cast(e[:aggregate_type], "text") }),
+            Sequel.pg_array(serialized_events.map { |e| e[:event_type] }),
+            Sequel.pg_array(serialized_events.map { |e| e[:aggregate_type] }),
             Sequel.pg_array(serialized_events.map { |e| e[:aggregate_sequence] }),
             Sequel.pg_array(serialized_events.map { |e| e[:body] }),
             Sequel.pg_array(serialized_events.map { |e| e[:metadata] }),

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -79,7 +79,7 @@ module EventFramework
           raise StaleAggregateError, "error saving aggregate_id #{aggregate_id}, aggregate_sequence mismatch"
         rescue Sequel::DatabaseLockTimeout => e
           logger.info(
-            msg: "event_framework.event_store.sink.lock_error",
+            msg: "event_framework.event_store.sink.unable_to_get_lock_error",
             correlation_id: staged_events.first.metadata.correlation_id
           )
           raise UnableToGetLockError, "error obtaining lock"

--- a/lib/event_framework/event_store/sink.rb
+++ b/lib/event_framework/event_store/sink.rb
@@ -3,7 +3,7 @@ module EventFramework
     class Sink
       AggregateIdMismatchError = Class.new(Error)
       UnableToGetLockError = Class.new(Error)
-      MultipleAggregateIDs = Class.new(Error)
+      MultipleAggregateIDsError = Class.new(Error)
       StaleAggregateError = Class.new(RetriableException)
 
       # 10 seconds
@@ -48,7 +48,7 @@ module EventFramework
       def sink_staged_events(staged_events)
         aggregate_id = begin
           ids = staged_events.map(&:aggregate_id)
-          raise MultipleAggregateIDs if ids.uniq.count != 1
+          raise MultipleAggregateIDsError if ids.uniq.count != 1
           ids.first
         end
 

--- a/spec/event_store/sink_spec.rb
+++ b/spec/event_store/sink_spec.rb
@@ -52,7 +52,8 @@ module EventFramework
         .all
     end
 
-    subject { described_class.new(database: database, event_type_resolver: event_type_resolver) }
+    let(:logger) { instance_spy(Logger) }
+    subject { described_class.new(database: database, event_type_resolver: event_type_resolver, logger: logger) }
 
     context "persisting a single event to the database" do
       let(:aggregate_id) { SecureRandom.uuid }

--- a/spec/event_store/sink_spec.rb
+++ b/spec/event_store/sink_spec.rb
@@ -149,6 +149,19 @@ module EventFramework
 
         subject.sink(staged_events)
       end
+
+      context "with multiple aggregate IDs" do
+        let(:staged_events) do
+          [
+            build_staged_event(aggregate_id: SecureRandom.uuid, aggregate_sequence: 1),
+            build_staged_event(aggregate_id: SecureRandom.uuid, aggregate_sequence: 2),
+          ]
+        end
+
+        it "raises an exception" do
+          expect { subject.sink(staged_events) }.to raise_error described_class::MultipleAggregateIDs
+        end
+      end
     end
 
     describe "optimistic locking" do

--- a/spec/event_store/sink_spec.rb
+++ b/spec/event_store/sink_spec.rb
@@ -161,6 +161,8 @@ module EventFramework
 
         it "raises a stale aggregate error" do
           expect { subject.sink(staged_events) }.to raise_error described_class::StaleAggregateError
+
+          expect(logger).to have_received(:info).with(msg: "event_framework.event_store.sink.stale_aggregate_error", correlation_id: metadata.correlation_id)
         end
 
         it "does not persist the event" do

--- a/spec/event_store/sink_spec.rb
+++ b/spec/event_store/sink_spec.rb
@@ -159,7 +159,7 @@ module EventFramework
         end
 
         it "raises an exception" do
-          expect { subject.sink(staged_events) }.to raise_error described_class::MultipleAggregateIDs
+          expect { subject.sink(staged_events) }.to raise_error described_class::MultipleAggregateIDsError
         end
       end
     end

--- a/spec/event_store/sink_spec.rb
+++ b/spec/event_store/sink_spec.rb
@@ -273,7 +273,7 @@ module EventFramework
           expect(database[:events].select_map(:aggregate_id)).to match [aggregate_id_1]
 
           expect(logger_1).to_not have_received(:info)
-          expect(logger_2).to have_received(:info).with(msg: "event_framework.event_store.sink.lock_error", correlation_id: metadata.correlation_id)
+          expect(logger_2).to have_received(:info).with(msg: "event_framework.event_store.sink.unable_to_get_lock_error", correlation_id: metadata.correlation_id)
         ensure
           disconnect_other_database_connection
         end

--- a/spec/reactor_spec.rb
+++ b/spec/reactor_spec.rb
@@ -75,6 +75,11 @@ module EventFramework
       context "when a concurrency exception occurs" do
         let(:domain_event) { test_event_2.new }
 
+        before do
+          # Suppress out stale aggregate log message
+          allow_any_instance_of(Logger).to receive(:info)
+        end
+
         it "retries saving the event" do
           sink.sink [
             EventFramework::StagedEvent.new(


### PR DESCRIPTION
### NOTE: This is a breaking change

To upgrade, the new migration needs to be copied into the host app and run before deploying the event framework code update.

---

We've been doing a lot of load testing and we discovered that multiple round trips to the database to begin the transaction, then take the lock, then sink the events was taking too long. This PR moves the locking functionality into a Postgresql function so we only need to talk to the database once when sinking events.

---

```
$ ./bin/demonstrate_event_sequence_id_gaps
# ...
actual sequences:       10022
processed sequences:    10022
unprocessed sequences:  0
Done
```