### PR TITLE
Tiny change so we can identify edge case errors better

### DIFF
--- a/spec/event_store/sink_spec.rb
+++ b/spec/event_store/sink_spec.rb
@@ -187,6 +187,19 @@ module EventFramework
           expect(persisted_tuples_for_aggregate(staged_events.first.aggregate_id).length).to eql 1
         end
       end
+
+      context "when there is a different type of unique constraint violation" do
+        let(:staged_events) {[build_staged_event(aggregate_sequence: 2)]}
+        let(:non_unique_event_sequence_violation) { Sequel::UniqueConstraintViolation.new("this text does not match") }
+
+        before do
+          allow(Sequel).to receive(:function).and_raise(non_unique_event_sequence_violation)
+        end
+
+        it "raises the error itself" do
+          expect { subject.sink(staged_events) }.to raise_error non_unique_event_sequence_violation
+        end
+      end
     end
 
     describe "locking" do


### PR DESCRIPTION
Change:

- Only raise `StaleAggregateError` for agg_id & agg_sequence unique constraint violation
- For any edge cases, raise the error