### PR TITLE
Wrap transaction around bookmark updates when handling events

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ EventFramework is the event-sourcing framework developed by the Murmur team. The
 API has been designed to make the happy-path simple, and the complex-path
 uncomplicated.
 
+## Contributing to this framework
+The follow commands make it possible for you to run tests and develop this library further:
+- `bin/setup`
+- `bin/task_runner reset_all`
+- `rspec`
+
 ## Domain Objects
 
 In order to reduce the risk of naming collisions with existing murmur code, domain

--- a/lib/event_framework/event_processor_supervisor.rb
+++ b/lib/event_framework/event_processor_supervisor.rb
@@ -53,14 +53,13 @@ module EventFramework
 
           event_processor = processor_class.new
 
-          EventProcessorWorker.call(
+          EventProcessorWorker.new(
             event_processor: event_processor,
             logger: logger,
             bookmark: bookmark,
             event_source: event_source,
-            tracer: tracer,
-            &ready_to_stop
-          )
+            tracer: tracer
+          ).call(&ready_to_stop)
         end
       end
 

--- a/lib/event_framework/event_processor_worker.rb
+++ b/lib/event_framework/event_processor_worker.rb
@@ -10,20 +10,19 @@ module EventFramework
 
     class << self
       def call(*args, &ready_to_stop)
-        new(*args, &ready_to_stop).call
+        new(*args).call(&ready_to_stop)
       end
     end
 
-    def initialize(event_processor:, logger:, event_source:, bookmark:, tracer:, &ready_to_stop)
+    def initialize(event_processor:, logger:, event_source:, bookmark:, tracer:)
       @event_processor = event_processor
       @logger = logger
       @event_source = event_source
       @bookmark = bookmark
       @tracer = tracer
-      @ready_to_stop = ready_to_stop
     end
 
-    def call
+    def call(&ready_to_stop)
       set_process_name
       log("forked")
       event_processor.logger = logger if event_processor.respond_to?(:logger=)
@@ -67,7 +66,7 @@ module EventFramework
 
     private
 
-    attr_reader :event_processor, :logger, :event_source, :bookmark, :tracer, :ready_to_stop
+    attr_reader :event_processor, :logger, :event_source, :bookmark, :tracer
 
     def fetch_events(sequence)
       if event_processor.all_handler?

--- a/lib/event_framework/version.rb
+++ b/lib/event_framework/version.rb
@@ -1,3 +1,3 @@
 module EventFramework
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/event_processor_worker_spec.rb
+++ b/spec/event_processor_worker_spec.rb
@@ -42,7 +42,7 @@ module EventFramework
           tracer: EventFramework::Tracer::NullTracer.new
         }
       end
-      subject(:event_processor_worker) { described_class.new(**event_processor_worker_arguments, &ready_to_stop) }
+      subject(:event_processor_worker) { described_class.new(**event_processor_worker_arguments) }
 
       before do
         allow(logger).to receive(:info)
@@ -52,7 +52,7 @@ module EventFramework
 
       def run_event_processor_worker
         catch :done do
-          event_processor_worker.call
+          event_processor_worker.call(&ready_to_stop)
         end
       end
 


### PR DESCRIPTION
This work makes possible to inject a custom worker into event framework runners.

The previous way instantiated these workers internally. We had no control how workers run. We can now write a worker to fit our needs (like log in a different fashion, etc). 

All the work is backward compatible. We kept the old APIs for the Runners and Supervisors working.

We needed more flexibility on how workers processed events. More specifically, we needed to [support database transactions around the event handling part so that murmur behaves a bit faster for the ResponseOutboxProjectorA](https://github.com/cultureamp/murmur/pull/19754).