### PR TITLE
Splat the hash to pass the kwargs to fork

### DIFF
--- a/lib/event_framework/event_processor_supervisor.rb
+++ b/lib/event_framework/event_processor_supervisor.rb
@@ -33,7 +33,7 @@ module EventFramework
           on_error: OnForkedError.new(processor_class.name)
         }
 
-        process_manager.fork(processor_class.name, fork_args) do |ready_to_stop|
+        process_manager.fork(processor_class.name, **fork_args) do |ready_to_stop|
           # Disconnect from the database to ensure the fork will create it's
           # own connection
           projection_database.disconnect


### PR DESCRIPTION
I was getting the following error when using the supervisor (trying to use it in the [recognition-service](https://github.com/cultureamp/recognition-service) project):
```shell
~/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/forked-0.1.2/lib/forked/process_manager.rb:14:in `fork': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
        from ~/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/bundler/gems/event_framework-a9f11e27e2a9/lib/event_framework/event_processor_supervisor.rb:36:in `block in call'
        from ~/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/bundler/gems/event_framework-a9f11e27e2a9/lib/event_framework/event_processor_supervisor.rb:30:in `each'
        from ~/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/bundler/gems/event_framework-a9f11e27e2a9/lib/event_framework/event_processor_supervisor.rb:30:in `call'
        from bin/run_event_processors:17:in `<main>'
```

This PR fixes the problem.