### PR TITLE
Splat the arg to initialize the EventProcessorWorker correctly

### DIFF
--- a/lib/event_framework/event_processor_worker.rb
+++ b/lib/event_framework/event_processor_worker.rb
@@ -9,8 +9,8 @@ module EventFramework
     DISABLED_SLEEP_INTERVAL = 10
 
     class << self
-      def call(*args, &ready_to_stop)
-        new(*args).call(&ready_to_stop)
+      def call(**args, &ready_to_stop)
+        new(**args).call(&ready_to_stop)
       end
     end
 


### PR DESCRIPTION
Missed out in #35. 

This is another place where we need to splat the arg correctly.