### PR TITLE
chore: bump dry-configurable

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.1"
           - "2.7"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,12 +7,18 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.1"
+          - "2.7"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby }}
     - uses: harmon758/postgresql-action@v1
       with:
         postgresql version: '11' # See https://hub.docker.com/_/postgres for available versions

--- a/event_framework.gemspec
+++ b/event_framework.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-auto_inject"
   spec.add_dependency "dry-struct", "~> 1.0"
   spec.add_dependency "dry-types", "~> 1.0"
-  spec.add_dependency "dry-configurable", "~> 0.13"
+  spec.add_dependency "dry-configurable", "~> 1.0.1"
   spec.add_dependency "dry-container"
   spec.add_dependency "dry-validation", "~> 1.7"
   spec.add_dependency "forked"

--- a/event_framework.gemspec
+++ b/event_framework.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-auto_inject"
   spec.add_dependency "dry-struct", "~> 1.0"
   spec.add_dependency "dry-types", "~> 1.0"
-  spec.add_dependency "dry-configurable", "~> 1.0.1"
+  spec.add_dependency "dry-configurable", ">= 0.13", "< 2"
   spec.add_dependency "dry-container"
   spec.add_dependency "dry-validation", "~> 1.7"
   spec.add_dependency "forked"

--- a/lib/event_framework/command.rb
+++ b/lib/event_framework/command.rb
@@ -1,4 +1,5 @@
 require "dry/struct"
+require "dry/validation"
 require "dry/validation/version"
 
 module EventFramework


### PR DESCRIPTION
## Objective

Bump to allow dry-configurable to 1.0.0+ while retaining backwards compatibility, as this unblocks Hanami 2.0.0+ (non-beta) upgrades

### Context

To unblock Hanami 2 upgrades.

### Changes

Bump dry-configurable dependency in gemspec, allowing 0.13 and 1.x versions

### Verification

Verified by passing test suite and comparing code coverage of specs against where dry-configurable is used.

### Checklist
* [x] I have tested the change locally.
* [x] I am basing off the correct branch.
* [x] I have updated any relevant documentation or left useful comments in the code.
* [x] I have reviewed the [security considerations](https://cultureamp.atlassian.net/wiki/spaces/AU/pages/923893881/Key+Security+Concepts) and highlighted them as appropriate.
