### PR TITLE
CA::LaunchDarkly for event-processor workers

### DIFF
--- a/lib/event_framework/event_processor_worker.rb
+++ b/lib/event_framework/event_processor_worker.rb
@@ -27,6 +27,12 @@ module EventFramework
       log("forked")
       event_processor.logger = logger if event_processor.respond_to?(:logger=)
 
+      begin
+        CA::LaunchDarkly.connect!
+      rescue
+        # CA::LaunchDarkly may not be available
+      end
+
       loop do
         tracer.trace("event.processor", resource: event_processor.class.name.to_s) do |span|
           # We're in a safe place to stop if we need to.
@@ -61,6 +67,12 @@ module EventFramework
             end
           end
         end
+      end
+
+      begin
+        CA::LaunchDarkly.shutdown!
+      rescue
+        # CA::LaunchDarkly may not be available
       end
     end
 


### PR DESCRIPTION
## Objective

Connect to LaunchDarkly for each of the event-processors' worker.


### Context

Each process managed by the `EventProcessorSupervisor` is run in a forked worker. If any of those processes needs to use LaunchDarkly, it needs to be `connect!`ed first.

### Changes

Attempt connecting to LaunchDarkly (via the [`ca-launchdarkly-ruby` gem](https://github.com/cultureamp/ca-launchdarkly-ruby#with-singleton-1)) when a new worker is spun up for each of the event-processors.

### Verification

Verified by a passing test suite and code coverage.

### Checklist
* [x] I have tested the change locally.
* [x] I am basing off the correct branch.
* [x] I have updated any relevant documentation or left useful comments in the code.
* [x] I have reviewed the [security considerations](https://cultureamp.atlassian.net/wiki/spaces/AU/pages/923893881/Key+Security+Concepts) and highlighted them as appropriate.
